### PR TITLE
Allow jumping while ducked

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ added by the plugin.
 
 * SourceMod 1.10
 * [DHooks with Detour Support](https://forums.alliedmods.net/showpost.php?p=2588686&postcount=589)
+* [MemoryPatch](https://github.com/Kenzzer/MemoryPatch) (compile only)
 
 ## ConVars
 
 * `sv_enablebunnyhopping ( def. "1" )` - Allow player speed to exceed maximum running speed
 * `sv_autobunnyhopping ( def. "1" )` - Players automatically re-jump while holding jump button
+* `sv_duckbunnyhopping ( def. "1" )` - Allow jumping while ducked
 
 It is recommended to set `sv_airaccelerate` to at least `150` if you intend to use this plugin.

--- a/addons/sourcemod/gamedata/tf-bhop.txt
+++ b/addons/sourcemod/gamedata/tf-bhop.txt
@@ -16,6 +16,28 @@
 				"linux"		"@_ZNK9CTFPlayer10CanAirDashEv"
 				"windows"	"\x2A\x2A\x2A\x2A\x2A\x2A\x57\x8B\xF9\xF7\x87\x84\x1A\x00\x00\x00\x00\x04\x00"
 			}
+			"CTFGameMovement::CheckJumpButton"
+			{
+				"library"	"server"
+				"linux"		"@_ZN15CTFGameMovement15CheckJumpButtonEv"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x0C\x57\x8B\xF9\x8B\x47\x04\x80\xB8\x54\x0A\x00\x00\x00"
+			}
+		}
+		"Addresses"
+		{
+			"MemoryPatch_AllowDuckJump"
+			{
+				"linux"
+				{
+					"signature"	"CTFGameMovement::CheckJumpButton"
+					"offset"	"204"	// CTFGameMovement::CheckJumpButton+CC
+				}
+				"windows"
+				{
+					"signature"	"CTFGameMovement::CheckJumpButton"
+					"offset"	"499"	// CTFGameMovement::CheckJumpButton+1F3
+				}
+			}
 		}
 		"Functions"
 		{
@@ -25,6 +47,14 @@
 				"callconv"	"thiscall"
 				"return"	"void"
 				"this"		"ignore"
+			}
+		}
+		"Keys"
+		{
+			"MemoryPatch_AllowDuckJump"
+			{
+				"linux"		"\xEB"	// jz short -> jmp short
+				"windows"	"\xEB"	// jz short -> jmp short
 			}
 		}
 	}


### PR DESCRIPTION
This PR allows players to jump while they are ducked. Can be configured with the `sv_duckbunnyhopping` convar.

Uses a memory patch to change the first byte of a `jz short` instruction to turn it into a `jmp short` instruction (`0x74` ->`0xEB`) in `CTFGameMovement::CheckJumpButton` and thus bypass the conditional that would prevent pressing `IN_JUMP` while ducked.

Increments the version to `v1.1`.
