### PR TITLE
Use memory patch instead of detour to allow bunnyjumping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
-# Team Fortress 2 Bunnyhop
+# Team Fortress 2 Bunnyhopping
 
 This is a simple SourceMod plugin that allows players to bunnyhop in Team Fortress 2.
 
-It is different to most other bunnyhop plugins, as it allows you to re-jump before the engine zeroes out
-your z-velocity. This makes bunnyhopping feel incedibly smooth, since no speed is lost and no velocity needs to be manually
-added by the plugin.
+Unlike most other bunnyhop plugins, this implementation makes you jump before the engine zeroes out your z-velocity, preserving 100% of your speed and making each jump feel buttery smooth.
 
 ## Features
 
-* Smooth auto-bhop by holding down the jump button
+* Smooth auto-bunnyhopping by holding down the jump button
     * No speed loss on a successful jump
     * Works well even with high ping
-    * Allows crouch-bhopping
+    * Allows jumping while ducked
 * Unlimited speed while bunnyhopping
     * Prevents `CTFGameMovement::PreventBunnyJumping` from getting called
 * Support for multiple jumps in mid-air (e.g. Scout's air dash, halloween spells, etc.)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ added by the plugin.
 ## Dependencies
 
 * SourceMod 1.10
-* [DHooks with Detour Support](https://forums.alliedmods.net/showpost.php?p=2588686&postcount=589)
 * [MemoryPatch](https://github.com/Kenzzer/MemoryPatch) (compile only)
 
 ## ConVars

--- a/addons/sourcemod/gamedata/tf-bhop.txt
+++ b/addons/sourcemod/gamedata/tf-bhop.txt
@@ -38,7 +38,7 @@
 					"offset"	"499"	// CTFGameMovement::CheckJumpButton+1F3
 				}
 			}
-			"MemoryPatch_PreventBunnyJumping"
+			"MemoryPatch_AllowBunnyJumping"
 			{
 				"linux"
 				{
@@ -59,7 +59,7 @@
 				"linux"		"\xEB"	// jz short -> jmp short
 				"windows"	"\xEB"	// jz short -> jmp short
 			}
-			"MemoryPatch_PreventBunnyJumping"
+			"MemoryPatch_AllowBunnyJumping"
 			{
 				"linux"		"\xEB"	// jz short -> jmp short
 				"windows"	"\xEB"	// jz short -> jmp short

--- a/addons/sourcemod/gamedata/tf-bhop.txt
+++ b/addons/sourcemod/gamedata/tf-bhop.txt
@@ -4,17 +4,11 @@
 	{
 		"Signatures"
 		{
-			"CTFGameMovement::PreventBunnyJumping"
-			{
-				"library"	"server"
-				"linux"		"@_ZN15CTFGameMovement19PreventBunnyJumpingEv"
-				"windows"	"\x56\x8B\xF1\x6A\x52\x8B\x8E\xA8\x07\x00\x00\x81\xC1\xB0\x19\x00\x00\xE8\x2A\x2A\x2A\x2A\x84\xC0\x75\x2A"
-			}
 			"CTFPlayer::CanAirDash"
 			{
 				"library"	"server"
 				"linux"		"@_ZNK9CTFPlayer10CanAirDashEv"
-				"windows"	"\x2A\x2A\x2A\x2A\x2A\x2A\x57\x8B\xF9\xF7\x87\x84\x1A\x00\x00\x00\x00\x04\x00"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x08\x57\x8B\xF9\xF7\x87\x84\x1A\x00\x00\x00\x00\x04\x00"
 			}
 			"CTFGameMovement::CheckJumpButton"
 			{
@@ -22,10 +16,16 @@
 				"linux"		"@_ZN15CTFGameMovement15CheckJumpButtonEv"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x0C\x57\x8B\xF9\x8B\x47\x04\x80\xB8\x54\x0A\x00\x00\x00"
 			}
+			"CTFGameMovement::PreventBunnyJumping"
+			{
+				"library"	"server"
+				"linux"		"@_ZN15CTFGameMovement19PreventBunnyJumpingEv"
+				"windows"	"\x56\x8B\xF1\x6A\x52\x8B\x8E\xA8\x07\x00\x00\x81\xC1\xB0\x19\x00\x00\xE8\x2A\x2A\x2A\x2A\x84\xC0\x75\x2A"
+			}
 		}
 		"Addresses"
 		{
-			"MemoryPatch_AllowDuckJump"
+			"MemoryPatch_AllowDuckJumping"
 			{
 				"linux"
 				{
@@ -38,20 +38,28 @@
 					"offset"	"499"	// CTFGameMovement::CheckJumpButton+1F3
 				}
 			}
-		}
-		"Functions"
-		{
-			"CTFGameMovement::PreventBunnyJumping"
+			"MemoryPatch_PreventBunnyJumping"
 			{
-				"signature"	"CTFGameMovement::PreventBunnyJumping"
-				"callconv"	"thiscall"
-				"return"	"void"
-				"this"		"ignore"
+				"linux"
+				{
+					"signature"	"CTFGameMovement::PreventBunnyJumping"
+					"offset"	"39"	// CTFGameMovement::PreventBunnyJumping+27
+				}
+				"windows"
+				{
+					"signature"	"CTFGameMovement::PreventBunnyJumping"
+					"offset"	"24"	// CTFGameMovement::PreventBunnyJumping+18
+				}
 			}
 		}
 		"Keys"
 		{
-			"MemoryPatch_AllowDuckJump"
+			"MemoryPatch_AllowDuckJumping"
+			{
+				"linux"		"\xEB"	// jz short -> jmp short
+				"windows"	"\xEB"	// jz short -> jmp short
+			}
+			"MemoryPatch_PreventBunnyJumping"
 			{
 				"linux"		"\xEB"	// jz short -> jmp short
 				"windows"	"\xEB"	// jz short -> jmp short

--- a/addons/sourcemod/scripting/tf-bhop.sp
+++ b/addons/sourcemod/scripting/tf-bhop.sp
@@ -36,7 +36,7 @@ ConVar sv_duckbunnyhopping;
 
 Handle g_SDKCallCanAirDash;
 MemoryPatch g_MemoryPatchAllowDuckJumping;
-MemoryPatch g_MemoryPatchPreventBunnyJumping;
+MemoryPatch g_MemoryPatchAllowBunnyJumping;
 
 bool g_InJumpRelease[MAXPLAYERS + 1];
 
@@ -75,18 +75,8 @@ public void OnPluginStart()
 	}
 	
 	MemoryPatch.SetGameData(gamedata);
-	
-	g_MemoryPatchAllowDuckJumping = new MemoryPatch("MemoryPatch_AllowDuckJumping");
-	if (g_MemoryPatchAllowDuckJumping != null)
-		g_MemoryPatchAllowDuckJumping.Enable();
-	else
-		LogError("Failed to create memory patch MemoryPatch_AllowDuckJumping");
-	
-	g_MemoryPatchPreventBunnyJumping = new MemoryPatch("MemoryPatch_PreventBunnyJumping");
-	if (g_MemoryPatchPreventBunnyJumping != null)
-		g_MemoryPatchPreventBunnyJumping.Enable();
-	else
-		LogError("Failed to create memory patch MemoryPatch_PreventBunnyJumping");
+	CreateMemoryPatch(g_MemoryPatchAllowDuckJumping, "MemoryPatch_AllowDuckJumping");
+	CreateMemoryPatch(g_MemoryPatchAllowBunnyJumping, "MemoryPatch_AllowBunnyJumping");
 	
 	delete gamedata;
 }
@@ -96,8 +86,8 @@ public void OnPluginEnd()
 	if (g_MemoryPatchAllowDuckJumping != null)
 		g_MemoryPatchAllowDuckJumping.Disable();
 	
-	if (g_MemoryPatchPreventBunnyJumping != null)
-		g_MemoryPatchPreventBunnyJumping.Disable();
+	if (g_MemoryPatchAllowBunnyJumping != null)
+		g_MemoryPatchAllowBunnyJumping.Disable();
 }
 
 public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3], int &weapon, int &subtype, int &cmdnum, int &tickcount, int &seed, int mouse[2])
@@ -144,13 +134,22 @@ public void ConVarChanged_DuckBunnyhopping(ConVar convar, const char[] oldValue,
 
 public void ConVarChanged_PreventBunnyJumping(ConVar convar, const char[] oldValue, const char[] newValue)
 {
-	if (g_MemoryPatchPreventBunnyJumping != null)
+	if (g_MemoryPatchAllowBunnyJumping != null)
 	{
 		if (convar.BoolValue)
-			g_MemoryPatchPreventBunnyJumping.Enable();
+			g_MemoryPatchAllowBunnyJumping.Enable();
 		else
-			g_MemoryPatchPreventBunnyJumping.Disable();
+			g_MemoryPatchAllowBunnyJumping.Disable();
 	}
+}
+
+void CreateMemoryPatch(MemoryPatch &handle, const char[] name)
+{
+	handle = new MemoryPatch(name);
+	if (handle != null)
+		handle.Enable();
+	else
+		LogError("Failed to create memory patch %s", name);
 }
 
 bool CanAirDash(int client)


### PR DESCRIPTION
This removes the dependency on DHooks.

Also returns the non-wildcarded signature of `CTFPlayer::CanAirDash`, since it was only wildcarded to be compatible with my air dash plugin (Mikusch/air-dash#1).