### PR TITLE
Allow clients to toggle auto-bunnyhopping as a preference

### DIFF
--- a/addons/sourcemod/scripting/tf-bhop.sp
+++ b/addons/sourcemod/scripting/tf-bhop.sp
@@ -55,7 +55,7 @@ public Plugin myinfo =
 	name = "Team Fortress 2 Bunnyhop", 
 	author = "Mikusch", 
 	description = "Simple TF2 bunnyhopping plugin", 
-	version = "1.4.7", 
+	version = "1.5.0", 
 	url = "https://github.com/Mikusch/tf-bhop"
 }
 

--- a/addons/sourcemod/scripting/tf-bhop.sp
+++ b/addons/sourcemod/scripting/tf-bhop.sp
@@ -81,6 +81,9 @@ public void OnPluginStart()
 	{
 		if (IsClientInGame(client))
 			OnClientPutInServer(client);
+		
+		if (AreClientCookiesCached(client))
+			OnClientCookiesCached(client);
 	}
 	
 	GameData gamedata = new GameData("tf-bhop");
@@ -160,7 +163,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 				{
 					g_InJumpRelease[client] = false;
 				}
-				else if (!g_InJumpRelease[client] && !g_IsAutobunnyHoppingDisabled[client] && !IsInAVehicle(client) && GetWaterLevel(client) < WL_Waist && !TF2_IsPlayerInCondition(client, TFCond_HalloweenGhostMode) && !TF2_IsPlayerInCondition(client, TFCond_GrapplingHookLatched))
+				else if (CanBunnyhop(client))
 				{
 					g_InTriggerPush = false;
 					
@@ -267,6 +270,16 @@ void CreateMemoryPatch(MemoryPatch &handle, const char[] name)
 		handle.Enable();
 	else
 		LogError("Failed to create memory patch %s", name);
+}
+
+bool CanBunnyhop(int client)
+{
+	return !g_IsAutobunnyHoppingDisabled[client]
+		&& !g_InJumpRelease[client]
+		&& !IsInAVehicle(client)
+		&& GetWaterLevel(client) < WL_Waist
+		&& !TF2_IsPlayerInCondition(client, TFCond_HalloweenGhostMode)
+		&& !TF2_IsPlayerInCondition(client, TFCond_GrapplingHookLatched);
 }
 
 bool CanAirDash(int client)

--- a/addons/sourcemod/scripting/tf-bhop.sp
+++ b/addons/sourcemod/scripting/tf-bhop.sp
@@ -18,6 +18,7 @@
 #include <sourcemod>
 #include <sdktools>
 #include <sdkhooks>
+#include <clientprefs>
 #include <tf2_stocks>
 #include <memorypatch>
 
@@ -37,6 +38,8 @@ ConVar sv_autobunnyhopping;
 ConVar sv_autobunnyhopping_falldamage;
 ConVar sv_duckbunnyhopping;
 
+Cookie g_CookieAutoBunnyhoppingDisabled;
+
 Handle g_SDKCallCanAirDash;
 Handle g_SDKCallAttribHookValue;
 MemoryPatch g_MemoryPatchAllowDuckJumping;
@@ -44,6 +47,7 @@ MemoryPatch g_MemoryPatchAllowBunnyJumping;
 
 bool g_IsBunnyHopping[MAXPLAYERS + 1];
 bool g_InJumpRelease[MAXPLAYERS + 1];
+bool g_IsAutobunnyHoppingDisabled[MAXPLAYERS + 1];
 bool g_InTriggerPush;
 
 public Plugin myinfo = 
@@ -66,6 +70,10 @@ public void OnPluginStart()
 	sv_autobunnyhopping_falldamage = CreateConVar("sv_autobunnyhopping_falldamage", "0", "Players can take fall damage while auto-bunnyhopping");
 	sv_duckbunnyhopping = CreateConVar("sv_duckbunnyhopping", "1", "Allow jumping while ducked");
 	sv_duckbunnyhopping.AddChangeHook(ConVarChanged_DuckBunnyhopping);
+	
+	g_CookieAutoBunnyhoppingDisabled = new Cookie("autobunnyhopping_disabled", "Do not automatically re-jump while holding jump button", CookieAccess_Protected);
+	
+	RegConsoleCmd("sm_bhop", ConCmd_ToggleAutoBunnyhopping, "Toggle auto-bunnyhopping preference");
 	
 	AutoExecConfig();
 	
@@ -131,6 +139,13 @@ public void OnClientPutInServer(int client)
 	SDKHook(client, SDKHook_OnTakeDamage, OnClientTakeDamage);
 }
 
+public void OnClientDisconnect(int client)
+{
+	g_IsBunnyHopping[client] = false;
+	g_InJumpRelease[client] = false;
+	g_IsAutobunnyHoppingDisabled[client] = false;
+}
+
 public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3], int &weapon, int &subtype, int &cmdnum, int &tickcount, int &seed, int mouse[2])
 {
 	if (sv_autobunnyhopping.BoolValue)
@@ -145,7 +160,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 				{
 					g_InJumpRelease[client] = false;
 				}
-				else if (!g_InJumpRelease[client] && !IsInAVehicle(client) && GetWaterLevel(client) < WL_Waist && !TF2_IsPlayerInCondition(client, TFCond_HalloweenGhostMode) && !TF2_IsPlayerInCondition(client, TFCond_GrapplingHookLatched))
+				else if (!g_InJumpRelease[client] && !g_IsAutobunnyHoppingDisabled[client] && !IsInAVehicle(client) && GetWaterLevel(client) < WL_Waist && !TF2_IsPlayerInCondition(client, TFCond_HalloweenGhostMode) && !TF2_IsPlayerInCondition(client, TFCond_GrapplingHookLatched))
 				{
 					g_InTriggerPush = false;
 					
@@ -172,6 +187,16 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	}
 }
 
+public void OnClientCookiesCached(int client)
+{
+	char value[8];
+	g_CookieAutoBunnyhoppingDisabled.Get(client, value, sizeof(value));
+	
+	bool result;
+	if (value[0] != '\0' && StringToIntEx(value, result) > 0)
+		g_IsAutobunnyHoppingDisabled[client] = result;
+}
+
 public void ConVarChanged_DuckBunnyhopping(ConVar convar, const char[] oldValue, const char[] newValue)
 {
 	if (g_MemoryPatchAllowDuckJumping)
@@ -192,6 +217,15 @@ public void ConVarChanged_PreventBunnyJumping(ConVar convar, const char[] oldVal
 		else
 			g_MemoryPatchAllowBunnyJumping.Disable();
 	}
+}
+
+public Action ConCmd_ToggleAutoBunnyhopping(int client, int args)
+{
+	g_IsAutobunnyHoppingDisabled[client] = !g_IsAutobunnyHoppingDisabled[client];
+	
+	char value[8];
+	if (IntToString(g_IsAutobunnyHoppingDisabled[client], value, sizeof(value)) > 0)
+		g_CookieAutoBunnyhoppingDisabled.Set(client, value);
 }
 
 public Action OnClientTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype)

--- a/addons/sourcemod/scripting/tf-bhop.sp
+++ b/addons/sourcemod/scripting/tf-bhop.sp
@@ -64,6 +64,8 @@ public void OnPluginStart()
 	if (GetEngineVersion() != Engine_TF2)
 		SetFailState("This plugin is only compatible with Team Fortress 2");
 	
+	LoadTranslations("tf-bhop.phrases");
+	
 	sv_enablebunnyhopping = CreateConVar("sv_enablebunnyhopping", "1", "Allow player speed to exceed maximum running speed");
 	sv_enablebunnyhopping.AddChangeHook(ConVarChanged_PreventBunnyJumping);
 	sv_autobunnyhopping = CreateConVar("sv_autobunnyhopping", "1", "Players automatically re-jump while holding jump button");
@@ -224,11 +226,13 @@ public void ConVarChanged_PreventBunnyJumping(ConVar convar, const char[] oldVal
 
 public Action ConCmd_ToggleAutoBunnyhopping(int client, int args)
 {
-	g_IsAutobunnyHoppingDisabled[client] = !g_IsAutobunnyHoppingDisabled[client];
+	bool value = g_IsAutobunnyHoppingDisabled[client] = !g_IsAutobunnyHoppingDisabled[client];
 	
-	char value[8];
-	if (IntToString(g_IsAutobunnyHoppingDisabled[client], value, sizeof(value)) > 0)
-		g_CookieAutoBunnyhoppingDisabled.Set(client, value);
+	char strValue[8];
+	if (IntToString(value, strValue, sizeof(strValue)) > 0)
+		g_CookieAutoBunnyhoppingDisabled.Set(client, strValue);
+	
+	ReplyToCommand(client, "%t", value ? "Auto-bunnyhopping disabled" : "Auto-bunnyhopping enabled");
 }
 
 public Action OnClientTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype)

--- a/addons/sourcemod/translations/tf-bhop.phrases.txt
+++ b/addons/sourcemod/translations/tf-bhop.phrases.txt
@@ -1,0 +1,12 @@
+"Phrases"
+{
+	"Auto-bunnyhopping enabled"
+	{
+		"en"		"You will now automatically re-jump while holding the jump button."
+	}
+	
+	"Auto-bunnyhopping disabled"
+	{
+		"en"		"You will no longer automatically re-jump while holding the jump button."
+	}
+}


### PR DESCRIPTION
Adds a simple `sm_bhop` command that allows disabling auto-bunnyhopping. This is stored using clientprefs.